### PR TITLE
Add support for django 2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
 *.pyc
+*.egg-info/
 
 env

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: python
 python:
-  - "2.7"
   - "3.4"
   - "3.6"
+  - "3.7"
 env:
   - DJANGO_VERSION=1.8.15
   - DJANGO_VERSION=1.9.9
   - DJANGO_VERSION=1.11
+  - DJANGO_VERSION=2.2.9
 install:
   - pip install -q Django==$DJANGO_VERSION
-  - pip install path.py
+  - pip install path
 script: python mail_templated/tests/runtests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.4"
+  - "3.5"
   - "3.6"
   - "3.7"
 env:

--- a/README.txt
+++ b/README.txt
@@ -1,12 +1,11 @@
+FOR DABAPPS USE ONLY
+
 ==========
 Django-Mail-Templated
 ==========
 
-This is a fork of `https://github.com/artemrizhov/django-mail-templated
-<https://github.com/artemrizhov/django-mail-templated/>`_. that includes support for template extension and supports Django 1.8 up to 1.11
-
-.. image:: https://travis-ci.org/maximilianhurl/django-mail-templated.svg
-   :target: https://travis-ci.org/maximilianhurl/django-mail-templated
+This is a fork of `https://github.com/maximilianhurl/django-mail-templated
+<https://github.com/maximilianhurl/django-mail-templated/>`_. that includes support for Django 2.2
 
 
 Overview
@@ -19,7 +18,7 @@ Installation
 =================
 Run::
 
-    $ pip install max-django-mail-templated
+    $ pip install git+https://github.com/dabapps/django-mail-templated.git#egg=django-mail-templated
 
 And register the app in your settings file::
 
@@ -141,7 +140,7 @@ Tests
 
 To run the unit tests you first need to create a virutal env in project root directory.
 
-    virtualenv env
+    python3 -m venv env
 
 Then you need to install the test requriements.
 

--- a/README.txt
+++ b/README.txt
@@ -7,6 +7,8 @@ Django-Mail-Templated
 This is a fork of `https://github.com/maximilianhurl/django-mail-templated
 <https://github.com/maximilianhurl/django-mail-templated/>`_. that includes support for Django 2.2
 
+Requires: Python >=3.5
+
 
 Overview
 =================

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Django>=1.6
-path.py==5.0
+Django==2.2.9
+path==13.1.0

--- a/setup.py
+++ b/setup.py
@@ -21,12 +21,12 @@ CLASSIFIERS = [
 ]
 
 setup(
-    name='max-django-mail-templated',
-    version='1.3',
+    name='dabapps-django-mail-templated',
+    version='2.0',
     packages=['mail_templated'],
-    author='Artem Rizhov, Max hurl',
+    author='Artem Rizhov, Max hurl, DabApps',
     author_email='artem.rizhov@gmail.com',
-    url='https://github.com/maximilianhurl/django-mail-templated',
+    url='https://github.com/dabapps/django-mail-templated',
     license='MIT',
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,


### PR DESCRIPTION
We are using `max-django-mail-templated` on a few of our projects, but it is no longer maintained.

With this fork we can maintain this in-house and support latest versions of Django and python.